### PR TITLE
Added test database support and real data tests

### DIFF
--- a/{{ cookiecutter.project_slug }}/alembic/versions/2022_07_03_0835-c05f1b900086_sprocket_widget_tables.py
+++ b/{{ cookiecutter.project_slug }}/alembic/versions/2022_07_03_0835-c05f1b900086_sprocket_widget_tables.py
@@ -22,7 +22,7 @@ def upgrade() -> None:
     sql_statements = [
         """
 CREATE TABLE IF NOT EXISTS widget (
-    uuid UUID PRIMARY KEY,
+    uuid UUID PRIMARY KEY default gen_random_uuid(),
     created TIMESTAMPTZ NOT NULL default CURRENT_TIMESTAMP,
     updated TIMESTAMPTZ NOT NULL default CURRENT_TIMESTAMP,
     name TEXT
@@ -36,7 +36,7 @@ CREATE TRIGGER update_timestamp
         """,
         """
 CREATE TABLE IF NOT EXISTS sprocket (
-    uuid UUID PRIMARY KEY,
+    uuid UUID PRIMARY KEY default gen_random_uuid(),
     created TIMESTAMPTZ NOT NULL default CURRENT_TIMESTAMP,
     updated TIMESTAMPTZ NOT NULL default CURRENT_TIMESTAMP,
     teeth INTEGER NOT NULL default 0,

--- a/{{ cookiecutter.project_slug }}/app/api/deps.py
+++ b/{{ cookiecutter.project_slug }}/app/api/deps.py
@@ -7,7 +7,7 @@ from databases import Database
 from app.db.database import app_database
 
 
-async def get_db() -> AsyncGenerator[Database, None]:
+async def get_app_db() -> AsyncGenerator[Database, None]:
     try:
         yield await app_database.get_database()
     finally:

--- a/{{ cookiecutter.project_slug }}/app/main.py
+++ b/{{ cookiecutter.project_slug }}/app/main.py
@@ -7,12 +7,24 @@ from fastapi.templating import Jinja2Templates
 
 from app.api.api_v1.api import api_router
 from app.core.config import settings
+from app.db.database import app_database
 
 BASE_PATH = Path(__file__).resolve().parent
 TEMPLATES = Jinja2Templates(directory=str(BASE_PATH / "templates"))
 
 root_router = APIRouter()
 app = FastAPI(title="{{ cookiecutter.project_name }}")
+
+
+@app.on_event("startup")
+async def startup_event() -> None:
+    app_database.config(settings.APP_DATABASE_URL)
+    await app_database.connect()
+
+
+@app.on_event("shutdown")
+async def shutdown_event() -> None:
+    await app_database.disconnect()
 
 
 @root_router.get("/", status_code=200)

--- a/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -56,4 +56,4 @@ warn_untyped_fields = true
 profile = "black"
 
 [tool.pytest.ini_options]
-asyncio_mode = "auto"
+asyncio_mode = "strict"

--- a/{{ cookiecutter.project_slug }}/test.sh
+++ b/{{ cookiecutter.project_slug }}/test.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
 
+alembic upgrade --tag TEST_RESET head
 pytest --cov=app tests/

--- a/{{ cookiecutter.project_slug }}/tests/config.py
+++ b/{{ cookiecutter.project_slug }}/tests/config.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import pathlib
+
+from databases import DatabaseURL
+from pydantic import AnyHttpUrl, BaseSettings, validator
+
+# Project Directories
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+class TestSettings(BaseSettings):
+
+    TEST_APP_DATABASE_URL: str | DatabaseURL = DatabaseURL(
+        "postgresql+asyncpg://db_user:db_pass@localhost:5432/test_app_db"
+    )
+
+    class Config:
+        case_sensitive = True
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+
+
+test_settings = TestSettings()

--- a/{{ cookiecutter.project_slug }}/tests/config.py
+++ b/{{ cookiecutter.project_slug }}/tests/config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pathlib
 
 from databases import DatabaseURL
-from pydantic import AnyHttpUrl, BaseSettings, validator
+from pydantic import BaseSettings
 
 # Project Directories
 ROOT = pathlib.Path(__file__).resolve().parent.parent

--- a/{{ cookiecutter.project_slug }}/tests/data/api_v1/endpoints/conftest.py
+++ b/{{ cookiecutter.project_slug }}/tests/data/api_v1/endpoints/conftest.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
-import pytest
+import pytest_asyncio
 from async_asgi_testclient import TestClient
+from databases import Database
 from fastapi import FastAPI
 
 from app.schemas import Widget
 
 
-@pytest.fixture
-async def widget(async_client: TestClient, app: FastAPI) -> Widget:
+@pytest_asyncio.fixture
+async def widget(async_client: TestClient, app: FastAPI, app_db: Database) -> Widget:
     url = app.url_path_for("create_widget")
     post_response = await async_client.post(url, json={"name": "widget"})
     return Widget(**post_response.json())

--- a/{{ cookiecutter.project_slug }}/tests/data/api_v1/endpoints/test_widget.py
+++ b/{{ cookiecutter.project_slug }}/tests/data/api_v1/endpoints/test_widget.py
@@ -2,21 +2,35 @@ from __future__ import annotations
 
 import random
 
+import pytest
 from async_asgi_testclient import TestClient
+from databases import Database
 from fastapi import FastAPI, status
 
 from app.schemas import Widget
 
 
-async def test_create_widget(async_client: TestClient, app: FastAPI) -> None:
+@pytest.mark.asyncio
+async def test_create_widget(
+    async_client: TestClient, app: FastAPI, app_db: Database
+) -> None:
     url = app.url_path_for("create_widget")
     response = await async_client.post(url, json={"name": "mega widget"})
+
+    # validate response
     assert response.status_code == status.HTTP_201_CREATED
     assert response.json()["name"] == "mega widget"
 
+    # validate data state
+    from_db = await app_db.fetch_one(
+        "SELECT * FROM widget WHERE uuid = :uuid", {"uuid": response.json()["uuid"]}
+    )
+    assert Widget.from_orm(from_db) == Widget(**response.json())
 
+
+@pytest.mark.asyncio
 async def test_get_widget(
-    async_client: TestClient, app: FastAPI, widget: Widget
+    async_client: TestClient, app: FastAPI, widget: Widget, app_db: Database
 ) -> None:
     url = app.url_path_for("get_widget", uuid=widget.uuid)
     response = await async_client.get(url)
@@ -24,8 +38,9 @@ async def test_get_widget(
     assert response.json()["uuid"] == str(widget.uuid)
 
 
+@pytest.mark.asyncio
 async def test_add_sprockets(
-    async_client: TestClient, app: FastAPI, widget: Widget
+    async_client: TestClient, app: FastAPI, widget: Widget, app_db: Database
 ) -> None:
     url = app.url_path_for("add_sprockets", uuid=widget.uuid)
     sprocket_teeth = [{"teeth": random.randrange(1, 10)} for _ in range(10)]

--- a/{{ cookiecutter.project_slug }}/tests/data/conftest.py
+++ b/{{ cookiecutter.project_slug }}/tests/data/conftest.py
@@ -1,11 +1,29 @@
 from __future__ import annotations
 
-import pytest
+import pytest_asyncio
 from async_asgi_testclient import TestClient
+from databases import Database, DatabaseURL
 from fastapi import FastAPI
 
+from app.db.database import app_database
 
-@pytest.fixture
+from ..config import test_settings
+
+test_db_url = DatabaseURL(test_settings.TEST_APP_DATABASE_URL)
+assert test_db_url.database.startswith(
+    "test"
+), "test database name must start with 'test'"
+app_database.config(test_db_url, force_rollback=True)
+
+
+@pytest_asyncio.fixture
 async def async_client(app: FastAPI) -> TestClient:
     async with TestClient(app) as client:
         yield client
+
+
+@pytest_asyncio.fixture(scope="function")
+async def app_db() -> Database:
+    await app_database.connect()
+    yield await app_database.get_database()
+    await app_database.disconnect()


### PR DESCRIPTION
- alembic takes `--tag TEST_RESET` to use `TEST_APP_DATABASE_URL` env and
  drop/create a new db (see `alembic/env.py`)
- added default to widget uuid pks in table create migration
- extended `AppDatabase` class for async test support, `force_rollback` in
  function scoped pytests
- `tests/config.py` with test_settings
- `test_create_widget.py` does a database validation
- fixed pytest `app_db` fixture to work against async test client and
  fixtures