### PR TITLE
9 add search database connector to db module

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -3,12 +3,13 @@
   "project_slug": "{{ cookiecutter.project_name|lower|replace(' ', '-') }}",
   "default_host": "0.0.0.0",
   "default_port": "8001",
-  "default_postgres_url": "http://db_user:db_pass@localhost:5432/app_db",
-  "default_search_url": "http://admin:admin@localhost:9200",
-  "search_backend": ["opensearch", "elasticsearch"],
+  "search_backend": ["elasticsearch", "opensearch"],
+  "default_postgres_url": "postgresql+asyncpg://db_user:db_pass@localhost:5432/app_db?sslmode=disable",
+  "default_search_url": "{% if cookiecutter.search_backend == 'elasticsearch' %}http://elastic:elastic@localhost:9200?sslmode=disable{% elif cookiecutter.search_backend == 'opensearch' %}http://admin:admin@localhost:9200?sslmode=disable{% endif %}",
   "initial_git_commit_message": "Initial commit from https://github.com/fapi-search/fastapi-search-cookiecutter template",
   "use_precommit": "y",
   "_copy_without_render": [
     "*.html"
-  ]
+  ],
+  "_extensions": ["local_extensions.test_database_url"]
 }

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -13,5 +13,10 @@ use_precommit = "{{ cookiecutter.use_precommit }}".lower().startswith("y")
 if use_precommit:
     print("*** pre-commit install ***")
     os.system("poetry run pre-commit install")
+    print("*** poetry run pre-commit run --all-files ***")
+    status = os.system("poetry run pre-commit run --all-files")
+    if status:
+        print("*** git commit -a -m 'pre-commit cleanup' ***")
+        os.system("git commit -a -m 'pre-commit cleanup'")
 else:
     os.unlink(".pre-commit-config.yaml")

--- a/local_extensions.py
+++ b/local_extensions.py
@@ -1,0 +1,11 @@
+import urllib
+from cookiecutter.utils import simple_filter
+
+
+@simple_filter
+def test_database_url(url):
+    parsed_url = urllib.parse.urlparse(url)
+    test_path_parts = parsed_url.path.split("/", 1)
+    test_path_parts[1] = "test_" + test_path_parts[1]
+    test_path = "/".join(test_path_parts)
+    return parsed_url._replace(path=test_path).geturl()

--- a/{{ cookiecutter.project_slug }}/.flake8
+++ b/{{ cookiecutter.project_slug }}/.flake8
@@ -5,6 +5,6 @@ inline-quotes = double
 type-checking-pydantic-enabled-baseclass-passlist = NamedTuple, TypedDict
 extend-immutable-calls = Depends, Path, Query, Body
 classmethod-decorators = classmethod, validator
-ignore = ANN101, FS003, TC002
+ignore = ANN101, D100, D103, D400, FS003, TC002
 per-file-ignores =
     alembic/env.py: E800

--- a/{{ cookiecutter.project_slug }}/app/api/api_v1/endpoints/widget.py
+++ b/{{ cookiecutter.project_slug }}/app/api/api_v1/endpoints/widget.py
@@ -5,9 +5,9 @@ from uuid import UUID, uuid4
 
 from databases import Database
 from fastapi import APIRouter, BackgroundTasks, Body, Depends, Path, status
-from opensearchpy._async.client import AsyncOpenSearch
 
 from app.api import deps
+from app.db.search import AsyncSearch
 from app.schemas import (
     Sprocket,
     SprocketCreate,
@@ -19,9 +19,9 @@ from app.schemas import (
 router = APIRouter()
 
 
-async def update_search(widget: Widget, search_db: AsyncOpenSearch) -> None:
+async def update_search(widget: Widget, search_db: AsyncSearch) -> None:
     response = await search_db.index(
-        index="widgets", body=widget.dict(), id=widget.uuid, refresh=True
+        index="widgets", {% if cookiecutter.search_backend == "elasticsearch" %}document{% elif cookiecutter.search_backend == "opensearch" %}body{% endif %}=widget.dict(), id=widget.uuid, refresh=True
     )
     if response["result"] not in ["created"]:
         print(response)
@@ -33,7 +33,7 @@ async def create_widget(
     widget_in: WidgetCreate,
     background_tasks: BackgroundTasks,
     app_db: Database = Depends(deps.get_app_db),
-    search_db: AsyncOpenSearch = Depends(deps.get_search_db),
+    search_db: AsyncSearch = Depends(deps.get_search_db),
 ) -> Widget:
     """Create a widget (MOCKED)"""
 

--- a/{{ cookiecutter.project_slug }}/app/api/deps.py
+++ b/{{ cookiecutter.project_slug }}/app/api/deps.py
@@ -3,12 +3,21 @@ from __future__ import annotations
 from typing import AsyncGenerator
 
 from databases import Database
+from opensearchpy._async.client import AsyncOpenSearch
 
 from app.db.database import app_database
+from app.db.search import search_database
 
 
 async def get_app_db() -> AsyncGenerator[Database, None]:
     try:
         yield await app_database.get_database()
+    finally:
+        pass
+
+
+async def get_search_db() -> AsyncGenerator[AsyncOpenSearch, None]:
+    try:
+        yield await search_database.get_database()
     finally:
         pass

--- a/{{ cookiecutter.project_slug }}/app/api/deps.py
+++ b/{{ cookiecutter.project_slug }}/app/api/deps.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 from typing import AsyncGenerator
 
 from databases import Database
-from opensearchpy._async.client import AsyncOpenSearch
 
 from app.db.database import app_database
-from app.db.search import search_database
+from app.db.search import AsyncSearch, search_database
 
 
 async def get_app_db() -> AsyncGenerator[Database, None]:
@@ -16,7 +15,7 @@ async def get_app_db() -> AsyncGenerator[Database, None]:
         pass
 
 
-async def get_search_db() -> AsyncGenerator[AsyncOpenSearch, None]:
+async def get_search_db() -> AsyncGenerator[AsyncSearch, None]:
     try:
         yield await search_database.get_database()
     finally:

--- a/{{ cookiecutter.project_slug }}/app/core/config.py
+++ b/{{ cookiecutter.project_slug }}/app/core/config.py
@@ -24,7 +24,11 @@ class Settings(BaseSettings):
         raise ValueError(v)
 
     APP_DATABASE_URL: str | DatabaseURL = DatabaseURL(
-        "postgresql+asyncpg://db_user:db_pass@localhost:5432/app_db"
+        "postgresql+asyncpg://db_user:db_pass@localhost:5432/app_db?sslmode=disable"
+    )
+
+    SEARCH_DATABASE_URL: str | DatabaseURL = DatabaseURL(
+        "https://admin:admin@localhost:9200?sslmode=disable"
     )
 
     class Config:

--- a/{{ cookiecutter.project_slug }}/app/core/config.py
+++ b/{{ cookiecutter.project_slug }}/app/core/config.py
@@ -24,11 +24,11 @@ class Settings(BaseSettings):
         raise ValueError(v)
 
     APP_DATABASE_URL: str | DatabaseURL = DatabaseURL(
-        "postgresql+asyncpg://db_user:db_pass@localhost:5432/app_db?sslmode=disable"
+        "{{ cookiecutter.default_postgres_url }}"  # noqa: E501
     )
 
     SEARCH_DATABASE_URL: str | DatabaseURL = DatabaseURL(
-        "https://admin:admin@localhost:9200?sslmode=disable"
+        "{{ cookiecutter.default_search_url }}"  # noqa: E501
     )
 
     class Config:

--- a/{{ cookiecutter.project_slug }}/app/db/search.py
+++ b/{{ cookiecutter.project_slug }}/app/db/search.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from databases import DatabaseURL
+from opensearchpy._async.client import AsyncOpenSearch
+
+
+class SearchDatabase:
+
+    _url: DatabaseURL
+    _database: AsyncOpenSearch
+
+    def config(self, url: str | DatabaseURL) -> None:
+        if hasattr(self, "_database"):
+            return
+        self._url = DatabaseURL(url) if isinstance(url, str) else url
+        verify_certs = self._url.options.get("sslmode", "require") in [
+            "require",
+            "verify-ca",
+            "verify-full",
+        ]
+        self._database = AsyncOpenSearch([str(self._url)], verify_certs=verify_certs)
+
+    async def get_database(self) -> AsyncOpenSearch:
+        assert hasattr(
+            self, "_database"
+        ), "Search database url not set, initialize with search_database.setup()"
+        return self._database
+
+
+search_database = SearchDatabase()

--- a/{{ cookiecutter.project_slug }}/app/db/search.py
+++ b/{{ cookiecutter.project_slug }}/app/db/search.py
@@ -1,28 +1,44 @@
 from __future__ import annotations
 
 from databases import DatabaseURL
-from opensearchpy._async.client import AsyncOpenSearch
 
+# use from app.db.search import AsyncSearch for portability
+{% if cookiecutter.search_backend == "elasticsearch" -%}
+from elasticsearch import AsyncElasticsearch as AsyncSearch
+{% elif cookiecutter.search_backend == "opensearch" -%}
+from opensearchpy._async.client import AsyncOpenSearch as AsyncSearch
+{% endif %}
 
 class SearchDatabase:
 
     _url: DatabaseURL
-    _database: AsyncOpenSearch
+    _database: AsyncSearch
 
     def config(self, url: str | DatabaseURL) -> None:
         if hasattr(self, "_database"):
             return
         self._url = DatabaseURL(url) if isinstance(url, str) else url
-        verify_certs = self._url.options.get("sslmode", "require") in [
+        self.verify_certs = self._url.options.get("sslmode", "require") in [
             "require",
             "verify-ca",
             "verify-full",
         ]
-        self._database = AsyncOpenSearch([str(self._url)], verify_certs=verify_certs)
 
-    async def get_database(self) -> AsyncOpenSearch:
+    async def connect(self) -> None:
         assert hasattr(
-            self, "_database"
+            self, "_url"
+        ), "Search database url not set, initialize with search_database.setup()"
+        self._database = AsyncSearch([str(self._url)], verify_certs=self.verify_certs)
+
+    async def disconnect(self) -> None:
+        assert hasattr(
+            self, "_url"
+        ), "Search database url not set, initialize with search_database.setup()"
+        await self._database.close()
+
+    async def get_database(self) -> AsyncSearch:
+        assert hasattr(
+            self, "_url"
         ), "Search database url not set, initialize with search_database.setup()"
         return self._database
 

--- a/{{ cookiecutter.project_slug }}/app/main.py
+++ b/{{ cookiecutter.project_slug }}/app/main.py
@@ -20,13 +20,15 @@ app = FastAPI(title="{{ cookiecutter.project_name }}")
 @app.on_event("startup")
 async def startup_event() -> None:
     app_database.config(settings.APP_DATABASE_URL)
-    search_database.config(settings.SEARCH_DATABASE_URL)
     await app_database.connect()
+    search_database.config(settings.SEARCH_DATABASE_URL)
+    await search_database.connect()
 
 
 @app.on_event("shutdown")
 async def shutdown_event() -> None:
     await app_database.disconnect()
+    await search_database.disconnect()
 
 
 @root_router.get("/", status_code=200)

--- a/{{ cookiecutter.project_slug }}/app/main.py
+++ b/{{ cookiecutter.project_slug }}/app/main.py
@@ -8,6 +8,7 @@ from fastapi.templating import Jinja2Templates
 from app.api.api_v1.api import api_router
 from app.core.config import settings
 from app.db.database import app_database
+from app.db.search import search_database
 
 BASE_PATH = Path(__file__).resolve().parent
 TEMPLATES = Jinja2Templates(directory=str(BASE_PATH / "templates"))
@@ -19,6 +20,7 @@ app = FastAPI(title="{{ cookiecutter.project_name }}")
 @app.on_event("startup")
 async def startup_event() -> None:
     app_database.config(settings.APP_DATABASE_URL)
+    search_database.config(settings.SEARCH_DATABASE_URL)
     await app_database.connect()
 
 
@@ -28,12 +30,8 @@ async def shutdown_event() -> None:
 
 
 @root_router.get("/", status_code=200)
-def root(
-    request: Request,
-) -> Response:
-    """
-    Root GET
-    """
+def root(request: Request) -> Response:
+    """Root GET"""
     return TEMPLATES.TemplateResponse("index.html", {"request": request})
 
 

--- a/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -13,6 +13,8 @@ databases = {extras = ["asyncpg"], version = "^0.6.0"}
 Jinja2 = "^3.1.2"
 alembic = "^1.8.0"
 alembic_utils = "^0.7.7"
+opensearch-py = "^2.0.0"
+aiohttp = "^3.8.1"
 
 [tool.poetry.dev-dependencies]
 black = "^22.6.0"

--- a/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -13,7 +13,11 @@ databases = {extras = ["asyncpg"], version = "^0.6.0"}
 Jinja2 = "^3.1.2"
 alembic = "^1.8.0"
 alembic_utils = "^0.7.7"
+{% if cookiecutter.search_backend == "elasticsearch" -%}
+elasticsearch = {extras = ["async"], version = "^8.3.1"}
+{% elif cookiecutter.search_backend == "opensearch" -%}
 opensearch-py = "^2.0.0"
+{% endif -%}
 aiohttp = "^3.8.1"
 
 [tool.poetry.dev-dependencies]

--- a/{{ cookiecutter.project_slug }}/tests/config.py
+++ b/{{ cookiecutter.project_slug }}/tests/config.py
@@ -12,7 +12,11 @@ ROOT = pathlib.Path(__file__).resolve().parent.parent
 class TestSettings(BaseSettings):
 
     TEST_APP_DATABASE_URL: str | DatabaseURL = DatabaseURL(
-        "postgresql+asyncpg://db_user:db_pass@localhost:5432/test_app_db"
+        "{{ cookiecutter.default_postgres_url | test_database_url }}"  # noqa: E501
+    )
+
+    TEST_SEARCH_DATABASE_URL: str | DatabaseURL = DatabaseURL(
+        "{{ cookiecutter.default_search_url }}"  # noqa: E501
     )
 
     class Config:

--- a/{{ cookiecutter.project_slug }}/tests/data/conftest.py
+++ b/{{ cookiecutter.project_slug }}/tests/data/conftest.py
@@ -6,14 +6,18 @@ from databases import Database, DatabaseURL
 from fastapi import FastAPI
 
 from app.db.database import app_database
+from app.db.search import search_database
 
 from ..config import test_settings
 
-test_db_url = DatabaseURL(test_settings.TEST_APP_DATABASE_URL)
-assert test_db_url.database.startswith(
+test_app_db_url = DatabaseURL(test_settings.TEST_APP_DATABASE_URL)
+assert test_app_db_url.database.startswith(
     "test"
 ), "test database name must start with 'test'"
-app_database.config(test_db_url, force_rollback=True)
+app_database.config(test_app_db_url, force_rollback=True)
+
+test_search_db_url = DatabaseURL(test_settings.TEST_SEARCH_DATABASE_URL)
+search_database.config(test_search_db_url)
 
 
 @pytest_asyncio.fixture
@@ -25,5 +29,7 @@ async def async_client(app: FastAPI) -> TestClient:
 @pytest_asyncio.fixture(scope="function")
 async def app_db() -> Database:
     await app_database.connect()
+    await search_database.connect()
     yield await app_database.get_database()
     await app_database.disconnect()
+    await search_database.disconnect()


### PR DESCRIPTION
Search database support for elasticsearch, opensearch

- updated database and search urls in project template
- added `test_database_url` jinja2 filter for default test database
  url
- run pre-commit on post gen and commit if changed
- search backend nuetral `AsyncSearch` in `app/db/search.py`
- tricky fixes for disconnecting search_database to avoid asyncio
  thread shutdown errors, in particular at end of `pytest` runs
- search search_database connector
- widgets index background task
